### PR TITLE
Fix link for Spree

### DIFF
--- a/source/projects/spree.md
+++ b/source/projects/spree.md
@@ -1,7 +1,7 @@
 ---
 title: Spree
 repo: spree/spree
-homepage: http://spreecommerce.com
+homepage: https://spreecommerce.org/
 demo: N/A
 language: Ruby
 framework: Ruby on Rails


### PR DESCRIPTION
The correct link is https://spreecommerce.org – .com points to some domain squatters.